### PR TITLE
Refactor unit tests

### DIFF
--- a/v2/bind.go
+++ b/v2/bind.go
@@ -42,7 +42,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 		}
 	}
 
-	response, err := c.prepareAndDoFunc(http.MethodPut, fullURL, requestBody)
+	response, err := c.prepareAndDo(http.MethodPut, fullURL, nil /* params */, requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -30,7 +30,7 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 		planID:    &requestPlanID,
 	}
 
-	response, err := c.prepareAndDoFunc(http.MethodDelete, fullURL, requestBody)
+	response, err := c.prepareAndDo(http.MethodDelete, fullURL, nil /* params */, requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/get_catalog.go
+++ b/v2/get_catalog.go
@@ -8,7 +8,7 @@ import (
 func (c *client) GetCatalog() (*CatalogResponse, error) {
 	fullURL := fmt.Sprintf(catalogURL, c.URL)
 
-	response, err := c.prepareAndDoFunc(http.MethodGet, fullURL, nil)
+	response, err := c.prepareAndDo(http.MethodGet, fullURL, nil /* params */, nil /* request body */)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/poll_last_operation.go
+++ b/v2/poll_last_operation.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 )
@@ -20,24 +19,21 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 	}
 
 	fullURL := fmt.Sprintf(lastOperationURLFmt, c.URL, r.InstanceID)
-	var queryParamBuffer bytes.Buffer
+	params := map[string]string{}
 	switch {
 	case r.ServiceID != nil:
-		appendQueryParam(&queryParamBuffer, serviceIDKey, *r.ServiceID)
+		params[serviceIDKey] = *r.ServiceID
 		fallthrough
 	case r.PlanID != nil:
-		appendQueryParam(&queryParamBuffer, planIDKey, *r.PlanID)
+		params[planIDKey] = *r.PlanID
 		fallthrough
 	case r.OperationKey != nil:
 		op := *r.OperationKey
 		opStr := string(op)
-		appendQueryParam(&queryParamBuffer, operationKey, opStr)
-	}
-	if queryParamBuffer.Len() > 0 {
-		fullURL += "?" + queryParamBuffer.String()
+		params[operationKey] = opStr
 	}
 
-	response, err := c.prepareAndDoFunc(http.MethodGet, fullURL, nil)
+	response, err := c.prepareAndDo(http.MethodGet, fullURL, params, nil /* request body */)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -28,8 +28,10 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 	}
 
 	fullURL := fmt.Sprintf(serviceInstanceURLFmt, c.URL, r.InstanceID)
+
+	params := map[string]string{}
 	if r.AcceptsIncomplete {
-		fullURL += "?accepts_incomplete=true"
+		params[asyncQueryParamKey] = "true"
 	}
 
 	requestBody := &provisionRequestBody{
@@ -40,7 +42,7 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		Parameters:       r.Parameters,
 	}
 
-	response, err := c.prepareAndDoFunc(http.MethodPut, fullURL, requestBody)
+	response, err := c.prepareAndDo(http.MethodPut, fullURL, params, requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/unbind.go
+++ b/v2/unbind.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 )
@@ -12,12 +11,11 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 	}
 
 	fullURL := fmt.Sprintf(bindingURLFmt, c.URL, r.InstanceID, r.BindingID)
-	var queryParamBuffer bytes.Buffer
-	appendQueryParam(&queryParamBuffer, serviceIDKey, r.ServiceID)
-	appendQueryParam(&queryParamBuffer, planIDKey, r.PlanID)
-	fullURL += "?" + queryParamBuffer.String()
+	params := map[string]string{}
+	params[serviceIDKey] = r.ServiceID
+	params[planIDKey] = r.PlanID
 
-	response, err := c.prepareAndDoFunc(http.MethodDelete, fullURL, nil)
+	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -32,7 +32,7 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 		parameters: r.Parameters,
 	}
 
-	response, err := c.prepareAndDoFunc(http.MethodPatch, fullURL, requestBody)
+	response, err := c.prepareAndDo(http.MethodPatch, fullURL, nil, requestBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To make them pure unit tests, allow testing request parameters, delineate object for http checks and reactions, etc.