### PR TITLE
Add clarification about GONE responses for async deprovisions

### DIFF
--- a/v2/errors.go
+++ b/v2/errors.go
@@ -39,6 +39,16 @@ func (e HTTPStatusCodeError) Error() string {
 	return fmt.Sprintf("Status: %v; ErrorMessage: %v; Description: %v", e.StatusCode, errorMessage, description)
 }
 
+// IsGoneError returns whether the error represents an HTTP GONE status.
+func IsGoneError(err error) bool {
+	statusCodeError, ok := err.(HTTPStatusCodeError)
+	if !ok {
+		return false
+	}
+
+	return statusCodeError.StatusCode == http.StatusGone
+}
+
 // IsConflictError returns whether the error represents a conflict.
 func IsConflictError(err error) bool {
 	statusCodeError, ok := err.(HTTPStatusCodeError)

--- a/v2/errors_test.go
+++ b/v2/errors_test.go
@@ -40,6 +40,40 @@ func TestIsConflictError(t *testing.T) {
 	}
 }
 
+func TestIsGoneError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "non-http error",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		{
+			name: "http non-gone error",
+			err: HTTPStatusCodeError{
+				StatusCode: http.StatusForbidden,
+			},
+			expected: false,
+		},
+		{
+			name: "http gone error",
+			err: HTTPStatusCodeError{
+				StatusCode: http.StatusGone,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		if e, a := tc.expected, IsGoneError(tc.err); e != a {
+			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -130,7 +130,9 @@ type Client interface {
 	// If the AcceptsIncomplete field of the request is set to true, the
 	// broker may complete the request asynchronously.  Callers should check
 	// the value of the Async field on the response and check the operation
-	// status using PollLastOperation if the Async field is true.
+	// status using PollLastOperation if the Async field is true.  Note that
+	// there are special semantics for PollLastOperation when checking the
+	// status of deprovision operations; see the doc for that method.
 	DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionResponse, error)
 	// PollLastOperation sends a request to query the last operation for a
 	// service instance to the broker and returns information about the
@@ -138,7 +140,14 @@ type Client interface {
 	// last operation endpoint for the requested instance ID
 	// (/v2/service_instances/instance-id/last_operation).
 	//
-	// Callers should periodically call PollLastOperation until
+	// Callers should periodically call PollLastOperation until they receive a
+	// success response.  PollLastOperation may return an HTTP GONE error for
+	// asynchronous deprovisions.  This is a valid response for async
+	// operations and means that the instance has been successfully
+	// deprovisioned.  When calling PollLastOperation to check the status of
+	// an asynchronous deprovision, callers check the status of an
+	// asynchronous deprovision, callers should test the value of the returned
+	// error with IsGoneError.
 	PollLastOperation(r *LastOperationRequest) (*LastOperationResponse, error)
 	// Bind requests a new binding between a service instance and an
 	// application and returns information about the binding or an error. Bind

--- a/v2/poll_last_operation.go
+++ b/v2/poll_last_operation.go
@@ -12,8 +12,6 @@ const (
 )
 
 func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationResponse, error) {
-	// TODO: support special handling for delete responses
-
 	if err := validateLastOperationRequest(r); err != nil {
 		return nil, err
 	}
@@ -46,10 +44,6 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 		}
 
 		return userResponse, nil
-	case http.StatusGone:
-		// TODO: async operations for deprovision have a special case to be
-		// handled here
-		fallthrough
 	default:
 		return nil, c.handleFailureResponse(response)
 	}


### PR DESCRIPTION
PollLastOperation may return an error for HTTP GONE responses from the broker, which is a valid response when checking the status of an async deprovision.