### PR TITLE
Semantic versioning; introduce v2.12

### DIFF
--- a/v2/bind_test.go
+++ b/v2/bind_test.go
@@ -152,7 +152,8 @@ func TestBind(t *testing.T) {
 			tc.httpChecks.body = defaultBindRequestBody
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.Bind(tc.request)
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -119,7 +119,7 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 		return nil, err
 	}
 
-	request.Header.Set(XBrokerAPIVersion, string(c.APIVersion))
+	request.Header.Set(XBrokerAPIVersion, c.APIVersion.HeaderValue())
 	if bodyReader != nil {
 		request.Header.Set(contentType, jsonType)
 	}

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -60,9 +60,10 @@ type httpReaction struct {
 	err    error
 }
 
-func newTestClient(t *testing.T, name string, enableAlpha bool, httpChecks httpChecks, httpReaction httpReaction) *client {
+func newTestClient(t *testing.T, name string, version APIVersion, enableAlpha bool, httpChecks httpChecks, httpReaction httpReaction) *client {
 	return &client{
 		Name:                "test client",
+		APIVersion:          version,
 		Verbose:             true,
 		URL:                 "https://example.com",
 		EnableAlphaFeatures: enableAlpha,

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -147,7 +147,8 @@ func TestDeprovisionInstance(t *testing.T) {
 			tc.httpChecks.body = "{}"
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.DeprovisionInstance(tc.request)
 

--- a/v2/get_catalog_test.go
+++ b/v2/get_catalog_test.go
@@ -271,7 +271,8 @@ func TestGetCatalog(t *testing.T) {
 			URL: "/v2/catalog",
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, httpChecks, tc.httpReaction)
 
 		response, err := klient.GetCatalog()
 

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -4,20 +4,6 @@ import (
 	"crypto/tls"
 )
 
-type APIVersion string
-
-const (
-	// APIVersion2_11 represents the 2.11 version of the Open Service Broker
-	// API.
-	APIVersion2_11 APIVersion = "2.11"
-)
-
-// LatestAPIVersion returns the latest supported API version in the current
-// release of this library.
-func LatestAPIVersion() APIVersion {
-	return APIVersion2_11
-}
-
 // AuthConfig is a union-type representing the possible auth configurations a
 // client may use to authenticate to a broker.  Currently, only basic auth is
 // supported.

--- a/v2/poll_last_operation_test.go
+++ b/v2/poll_last_operation_test.go
@@ -126,7 +126,8 @@ func TestPollLastOperation(t *testing.T) {
 			tc.httpChecks.params[planIDKey] = testPlanID
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.PollLastOperation(tc.request)
 

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -15,7 +15,7 @@ type provisionRequestBody struct {
 	OrganizationGUID string                 `json:"organization_guid"`
 	SpaceGUID        string                 `json:"space_guid"`
 	Parameters       map[string]interface{} `json:"parameters,omitempty"`
-	AlphaContext     map[string]interface{} `json:"context,omitempty"`
+	Context          map[string]interface{} `json:"context,omitempty"`
 }
 
 type provisionSuccessResponseBody struct {
@@ -43,8 +43,8 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		Parameters:       r.Parameters,
 	}
 
-	if c.EnableAlphaFeatures {
-		requestBody.AlphaContext = r.AlphaContext
+	if c.APIVersion.AtLeast(Version2_12()) {
+		requestBody.Context = r.Context
 	}
 
 	response, err := c.prepareAndDo(http.MethodPut, fullURL, params, requestBody)

--- a/v2/provision_instance_test.go
+++ b/v2/provision_instance_test.go
@@ -57,11 +57,14 @@ func successProvisionResponseAsync() *ProvisionResponse {
 	return r
 }
 
-const alphaContextProvisionRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","organization_guid":"test-organization-guid","space_guid":"test-space-guid","context":{"foo":"bar"}}`
+const contextProvisionRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","organization_guid":"test-organization-guid","space_guid":"test-space-guid","context":{"foo":"bar"}}`
 
 func TestProvisionInstance(t *testing.T) {
+	v2_12 := Version2_12()
+
 	cases := []struct {
 		name               string
+		version            *APIVersion
 		enableAlpha        bool
 		request            *ProvisionRequest
 		httpChecks         httpChecks
@@ -141,17 +144,35 @@ func TestProvisionInstance(t *testing.T) {
 			expectedErr: testHttpStatusCodeError(),
 		},
 		{
-			name:        "alpha - context",
-			enableAlpha: true,
+			name:    "context - 2.12",
+			version: &v2_12,
 			request: func() *ProvisionRequest {
 				r := defaultProvisionRequest()
-				r.AlphaContext = map[string]interface{}{
+				r.Context = map[string]interface{}{
 					"foo": "bar",
 				}
 				return r
 			}(),
 			httpChecks: httpChecks{
-				body: alphaContextProvisionRequestBody,
+				body: contextProvisionRequestBody,
+			},
+			httpReaction: httpReaction{
+				status: http.StatusCreated,
+				body:   successProvisionResponseBody,
+			},
+			expectedResponse: successProvisionResponse(),
+		},
+		{
+			name: "context - 2.11",
+			request: func() *ProvisionRequest {
+				r := defaultProvisionRequest()
+				r.Context = map[string]interface{}{
+					"foo": "bar",
+				}
+				return r
+			}(),
+			httpChecks: httpChecks{
+				body: successProvisionRequestBody,
 			},
 			httpReaction: httpReaction{
 				status: http.StatusCreated,
@@ -174,7 +195,13 @@ func TestProvisionInstance(t *testing.T) {
 			tc.httpChecks.body = successProvisionRequestBody
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		defaultVersion := Version2_11()
+		version := &defaultVersion
+		if tc.version != nil {
+			version = tc.version
+		}
+
+		klient := newTestClient(t, tc.name, *version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.ProvisionInstance(tc.request)
 

--- a/v2/types.go
+++ b/v2/types.go
@@ -149,15 +149,10 @@ type ProvisionRequest struct {
 	// Parameters is a set of configuration options for the service instance.
 	// Optional.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
-	// AlphaContext is an ALPHA field and may change or disappear at any time.
-	// AlphaContext will only be sent if alpha features are enabled in the
-	// client.
-	//
-	// AlphaContext is platform-specific contextual information under which
-	// the service instance is to be provisioned.
-	//
-	// For more information, see: https://github.com/openservicebrokerapi/servicebroker/issues/115
-	AlphaContext map[string]interface{} `json:"context,omitempty"`
+	// Context is platform-specific contextual information under which the
+	// service instance is to be provisioned.  Context was added in version
+	// 2.12 of the OSB API and is only sent for versions 2.12 or later.
+	Context map[string]interface{} `json:"context,omitempty"`
 }
 
 // ProvisionResponse is sent in response to a provision call

--- a/v2/unbind_test.go
+++ b/v2/unbind_test.go
@@ -97,7 +97,8 @@ func TestUnbind(t *testing.T) {
 			tc.httpChecks.params[planIDKey] = testPlanID
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.Unbind(tc.request)
 

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -139,7 +139,8 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			tc.httpChecks.body = "{}"
 		}
 
-		klient := newTestClient(t, tc.name, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		version := Version2_11()
+		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.UpdateInstance(tc.request)
 

--- a/v2/version.go
+++ b/v2/version.go
@@ -1,0 +1,43 @@
+package v2
+
+// APIVersion represents a specific version of the OSB API.
+type APIVersion struct {
+	label string
+	order byte
+}
+
+// AtLeast returns whether the API version is greater than or equal to the
+// given API version.
+func (v APIVersion) AtLeast(test APIVersion) bool {
+	return v.order >= test.order
+}
+
+// HeaderValue returns the value that should be sent in the API version header
+// for this API version.
+func (v APIVersion) HeaderValue() string {
+	return v.label
+}
+
+const (
+	// internalAPIVersion2_11 represents the 2.11 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_11 = "2.11"
+
+	// internalAPIVersion2_11 represents the 2.11 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_12 = "2.12"
+)
+
+func Version2_12() APIVersion {
+	return APIVersion{label: internalAPIVersion2_12, order: 1}
+}
+
+func Version2_11() APIVersion {
+	return APIVersion{label: internalAPIVersion2_12, order: 0}
+}
+
+// LatestAPIVersion returns the latest supported API version in the current
+// release of this library.
+func LatestAPIVersion() APIVersion {
+	return Version2_12()
+}

--- a/v2/version_test.go
+++ b/v2/version_test.go
@@ -1,0 +1,18 @@
+package v2
+
+import (
+	"testing"
+)
+
+func TestAtLeast(t *testing.T) {
+	v2_12 := Version2_12()
+	v2_11 := Version2_11()
+
+	if !v2_12.AtLeast(v2_11) {
+		t.Error("Expected 2.12 >= 2.11")
+	}
+
+	if v2_11.AtLeast(v2_12) {
+		t.Error("Expected 2.11 < 2.12")
+	}
+}


### PR DESCRIPTION
Adds support for version 2.12; removes alpha support for Context in earlier versions.  `LatestAPIVersion` now returns 2.12.