### PR TITLE
Correctly model and handle malformed broker responses

### DIFF
--- a/v2/bind.go
+++ b/v2/bind.go
@@ -51,7 +51,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 	case http.StatusOK, http.StatusCreated:
 		userResponse := &BindResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/v2/bind_test.go
+++ b/v2/bind_test.go
@@ -119,7 +119,7 @@ func TestBind(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -127,7 +127,7 @@ func TestBind(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",

--- a/v2/client.go
+++ b/v2/client.go
@@ -173,7 +173,7 @@ func (c *client) handleFailureResponse(response *http.Response) error {
 	glog.Info("handling failure responses")
 	brokerResponse := &failureResponseBody{}
 	if err := c.unmarshalResponse(response, brokerResponse); err != nil {
-		return err
+		return HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 	}
 
 	return HTTPStatusCodeError{

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -25,7 +25,11 @@ const conventionalFailureResponseBody = `{
 func testHttpStatusCodeError() error {
 	errorMessage := "TestError"
 	description := "test error description"
-	return HTTPStatusCodeError{http.StatusInternalServerError, &errorMessage, &description}
+	return HTTPStatusCodeError{
+		StatusCode:   http.StatusInternalServerError,
+		ErrorMessage: &errorMessage,
+		Description:  &description,
+	}
 }
 
 func truePtr() *bool {

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -122,7 +122,7 @@ func TestDeprovisionInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",

--- a/v2/get_catalog.go
+++ b/v2/get_catalog.go
@@ -17,7 +17,7 @@ func (c *client) GetCatalog() (*CatalogResponse, error) {
 	case http.StatusOK:
 		catalogResponse := &CatalogResponse{}
 		if err := c.unmarshalResponse(response, catalogResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		if !c.EnableAlphaFeatures {

--- a/v2/get_catalog_test.go
+++ b/v2/get_catalog_test.go
@@ -229,7 +229,7 @@ func TestGetCatalog(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -237,10 +237,10 @@ func TestGetCatalog(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
-			name: "500 with malformed response",
+			name: "500 with conventional response",
 			httpReaction: httpReaction{
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,

--- a/v2/poll_last_operation.go
+++ b/v2/poll_last_operation.go
@@ -40,7 +40,7 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 	case http.StatusOK:
 		userResponse := &LastOperationResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/v2/poll_last_operation_test.go
+++ b/v2/poll_last_operation_test.go
@@ -91,7 +91,7 @@ func TestPollLastOperation(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -99,10 +99,10 @@ func TestPollLastOperation(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
-			name: "500 with malformed response",
+			name: "500 with convential response",
 			httpReaction: httpReaction{
 				status: http.StatusInternalServerError,
 				body:   conventionalFailureResponseBody,

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -56,7 +56,7 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 	case http.StatusCreated, http.StatusOK, http.StatusAccepted:
 		responseBodyObj := &provisionSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		var opPtr *OperationKey

--- a/v2/provision_instance_test.go
+++ b/v2/provision_instance_test.go
@@ -125,7 +125,7 @@ func TestProvisionInstance(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -133,7 +133,7 @@ func TestProvisionInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",

--- a/v2/unbind.go
+++ b/v2/unbind.go
@@ -24,7 +24,7 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 	case http.StatusOK, http.StatusGone:
 		userResponse := &UnbindResponse{}
 		if err := c.unmarshalResponse(response, userResponse); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		return userResponse, nil

--- a/v2/unbind_test.go
+++ b/v2/unbind_test.go
@@ -62,7 +62,7 @@ func TestUnbind(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -70,7 +70,7 @@ func TestUnbind(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -40,11 +40,15 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 
 	switch response.StatusCode {
 	case http.StatusOK:
+		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
+		}
+
 		return &UpdateInstanceResponse{}, nil
 	case http.StatusAccepted:
 		responseBodyObj := &asyncSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
-			return nil, err
+			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
 		var opPtr *OperationKey

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -91,7 +91,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusAccepted,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "http error",
@@ -106,7 +106,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusOK,
 				body:   malformedResponse,
 			},
-			expectedResponse: successUpdateInstanceResponse(),
+			expectedErrMessage: "Status: 200; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with malformed response",
@@ -114,7 +114,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				status: http.StatusInternalServerError,
 				body:   malformedResponse,
 			},
-			expectedErrMessage: "unexpected end of JSON input",
+			expectedErrMessage: "Status: 500; ErrorMessage: <nil>; Description: <nil>; ResponseError: unexpected end of JSON input",
 		},
 		{
 			name: "500 with conventional failure response",


### PR DESCRIPTION
The OSB spec states that platforms must differentiate between the HTTP status codes when a malformed response body is returned (see https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#orphans).  This change begins returning that data to the user, and fixes a couple cases that were not erroring when they should have with malformed response bodies.