### PR TITLE
Make HTTPStatusCodeError error method print strings

### DIFF
--- a/v2/errors.go
+++ b/v2/errors.go
@@ -38,7 +38,16 @@ type HTTPStatusCodeError struct {
 }
 
 func (e HTTPStatusCodeError) Error() string {
-	return fmt.Sprintf("Status: %v; ErrorMessage: %v; Description: %v; ResponseError: %v", e.StatusCode, e.ErrorMessage, e.Description, e.ResponseError)
+	errorMessage := "<nil>"
+	description := "<nil>"
+
+	if e.ErrorMessage != nil {
+		errorMessage = *e.ErrorMessage
+	}
+	if e.Description != nil {
+		description = *e.Description
+	}
+	return fmt.Sprintf("Status: %v; ErrorMessage: %v; Description: %v; ResponseError: %v", e.StatusCode, errorMessage, description, e.ResponseError)
 }
 
 // IsHTTPError returns whether the error represents an HTTPStatusCodeError.  A

--- a/v2/errors_test.go
+++ b/v2/errors_test.go
@@ -197,3 +197,41 @@ func TestIsAppGUIDRequiredError(t *testing.T) {
 		}
 	}
 }
+
+func TestHttpStatusCodeError(t *testing.T) {
+	cases := []struct {
+		name           string
+		err            error
+		expectedOutput string
+	}{
+		{
+			name: "async required error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(AsyncErrorMessage),
+				Description:  strPtr(AsyncErrorDescription),
+			},
+			expectedOutput: "Status: 422; ErrorMessage: AsyncRequired; Description: This service plan requires client support for asynchronous service operations.; ResponseError: <nil>",
+		},
+		{
+			name: "app guid required error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(AppGUIDRequiredErrorMessage),
+				Description:  strPtr(AppGUIDRequiredErrorDescription),
+			},
+			expectedOutput: "Status: 422; ErrorMessage: RequiresApp; Description: This service supports generation of credentials through binding an application only.; ResponseError: <nil>",
+		},
+		{
+			name:           "blank error",
+			err:            HTTPStatusCodeError{},
+			expectedOutput: "Status: 0; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
+		},
+	}
+
+	for _, tc := range cases {
+		if e, a := tc.expectedOutput, tc.err.Error(); e != a {
+			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}


### PR DESCRIPTION
I think printing the error strings when populated is what is desired here, but perhaps a better strategy could be utilized rather than this.