### PR TITLE
Fixes #51: Send service ID and plan ID as query parameters for deprovision

### DIFF
--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -5,13 +5,6 @@ import (
 	"net/http"
 )
 
-// internal message body types
-
-type deprovisionInstanceRequestBody struct {
-	serviceID *string `json:"service_id"`
-	planID    *string `json:"plan_id,omitempty"`
-}
-
 func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionResponse, error) {
 	if err := validateDeprovisionRequest(r); err != nil {
 		return nil, err
@@ -19,20 +12,15 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 
 	fullURL := fmt.Sprintf(serviceInstanceURLFmt, c.URL, r.InstanceID)
 
-	params := map[string]string{}
+	params := map[string]string{
+		serviceIDKey: string(r.ServiceID),
+		planIDKey:    string(r.PlanID),
+	}
 	if r.AcceptsIncomplete {
 		params[asyncQueryParamKey] = "true"
 	}
 
-	requestServiceID := string(r.ServiceID)
-	requestPlanID := string(r.PlanID)
-
-	requestBody := &deprovisionInstanceRequestBody{
-		serviceID: &requestServiceID,
-		planID:    &requestPlanID,
-	}
-
-	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, requestBody)
+	response, err := c.prepareAndDo(http.MethodDelete, fullURL, params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -63,6 +63,12 @@ func TestDeprovisionInstance(t *testing.T) {
 				status: http.StatusOK,
 				body:   successDeprovisionResponseBody,
 			},
+			httpChecks: httpChecks{
+				params: map[string]string{
+					serviceIDKey: string(testServiceID),
+					planIDKey:    string(testPlanID),
+				},
+			},
 			expectedResponse: successDeprovisionResponse(),
 		},
 		{
@@ -141,10 +147,6 @@ func TestDeprovisionInstance(t *testing.T) {
 
 		if tc.httpChecks.URL == "" {
 			tc.httpChecks.URL = "/v2/service_instances/test-instance-id"
-		}
-
-		if tc.httpChecks.body == "" {
-			tc.httpChecks.body = "{}"
 		}
 
 		version := Version2_11()


### PR DESCRIPTION
Closes #51 

A Deprovision request should have the service ID and plan ID sent as query parameters rather than sent as part of the request body.