### PR TITLE
Use supplied cert data for TLS authentication

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"io"
@@ -40,6 +41,15 @@ func NewClient(config *ClientConfiguration) (Client, error) {
 	}
 	if config.Insecure {
 		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	if len(config.CAData) != 0 {
+		if transport.TLSClientConfig.RootCAs == nil {
+			transport.TLSClientConfig.RootCAs = x509.NewCertPool()
+		}
+		transport.TLSClientConfig.RootCAs.AppendCertsFromPEM(config.CAData)
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify && transport.TLSClientConfig.RootCAs != nil {
+		return nil, errors.New("Cannot specify root CAs and to skip TLS verification")
 	}
 	httpClient.Transport = transport
 

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -9,7 +9,7 @@ import (
 // supported.
 type AuthConfig struct {
 	BasicAuthConfig *BasicAuthConfig
-	BearerConfig *BearerConfig
+	BearerConfig    *BearerConfig
 }
 
 // BasicAuthConfig represents a set of basic auth credentials.
@@ -61,6 +61,9 @@ type ClientConfiguration struct {
 	// any request parameters or request or response fields that correspond to
 	// alpha features.
 	EnableAlphaFeatures bool
+	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+	// This CA certificate will be added to any specified in TLSConfig.RootCAs.
+	CAData []byte
 }
 
 // DefaultClientConfiguration returns a default ClientConfiguration:


### PR DESCRIPTION
Fixes #53. Cert data is passed to the client in ClientConfiguration.CAData.