### PR TITLE
treat 202 as an error when async not supported

### DIFF
--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -30,6 +30,8 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 		return &DeprovisionResponse{}, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
+			// If the client did not signify that it could handle asynchronous
+			// operations, a '202 Accepted' response should be treated as an error.
 			return nil, c.handleFailureResponse(response)
 		}
 

--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -29,6 +29,10 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 	case http.StatusOK, http.StatusGone:
 		return &DeprovisionResponse{}, nil
 	case http.StatusAccepted:
+		if !r.AcceptsIncomplete {
+			return nil, c.handleFailureResponse(response)
+		}
+
 		responseBodyObj := &asyncSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, err

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -116,6 +116,14 @@ func TestDeprovisionInstance(t *testing.T) {
 			expectedErrMessage: "http error",
 		},
 		{
+			name: "202 with no async support",
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncDeprovisionResponseBody,
+			},
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
+		},
+		{
 			name: "200 with malformed response",
 			httpReaction: httpReaction{
 				status: http.StatusOK,

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -62,6 +62,8 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		return userResponse, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
+			// If the client did not signify that it could handle asynchronous
+			// operations, a '202 Accepted' response should be treated as an error.
 			return nil, c.handleFailureResponse(response)
 		}
 

--- a/v2/provision_instance_test.go
+++ b/v2/provision_instance_test.go
@@ -121,6 +121,14 @@ func TestProvisionInstance(t *testing.T) {
 			expectedErrMessage: "http error",
 		},
 		{
+			name: "202 with no async support",
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncProvisionResponseBody,
+			},
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
+		},
+		{
 			name: "200 with malformed response",
 			httpReaction: httpReaction{
 				status: http.StatusOK,

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -47,6 +47,8 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 		return &UpdateInstanceResponse{}, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
+			// If the client did not signify that it could handle asynchronous
+			// operations, a '202 Accepted' response should be treated as an error.
 			return nil, c.handleFailureResponse(response)
 		}
 

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -46,6 +46,10 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 
 		return &UpdateInstanceResponse{}, nil
 	case http.StatusAccepted:
+		if !r.AcceptsIncomplete {
+			return nil, c.handleFailureResponse(response)
+		}
+
 		responseBodyObj := &asyncSuccessResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -102,6 +102,14 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			expectedErrMessage: "http error",
 		},
 		{
+			name: "202 with no async support",
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncUpdateInstanceResponseBody,
+			},
+			expectedErrMessage: "Status: 202; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
+		},
+		{
 			name: "200 with malformed response",
 			httpReaction: httpReaction{
 				status: http.StatusOK,


### PR DESCRIPTION
A `202 Accepted` response from the broker during a provision/deprovision without `accepts_incomplete` supplied should be treated as an error.