### PR TITLE
Remove OriginatingIdentity from ProvisionResponse

### DIFF
--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -23,7 +23,7 @@ const (
 	testOriginatingIdentityHeaderValue = "fakeplatform eyJ1c2VyIjoibmFtZSJ9"
 )
 
-var testOriginatingIdentity *AlphaOriginatingIdentity = &AlphaOriginatingIdentity{
+var testOriginatingIdentity = &AlphaOriginatingIdentity{
 	Platform: testOriginatingIdentityPlatform,
 	Value:    testOriginatingIdentityValue,
 }

--- a/v2/types.go
+++ b/v2/types.go
@@ -182,8 +182,6 @@ type ProvisionResponse struct {
 	// OperationKey is an extra identifier supplied by the broker to identify
 	// asynchronous operations.
 	OperationKey *OperationKey `json:"operationKey,omitempty"`
-	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity AlphaOriginatingIdentity
 }
 
 // OperationKey is an extra identifier from the broker in order to provide extra


### PR DESCRIPTION
Remove the unused OriginatingIdentity field from the ProvisionResponse struct. The originating identity is not something sent in a response from a Broker.

Fixed a lint error.