### PR TITLE
update client for 2.13 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ func GetBrokerCatalog(URL string) (*osb.CatalogResponse, error) {
 This client library supports the following versions of the
 [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker):
 
+- [v2.13](https://github.com/openservicebrokerapi/servicebroker/tree/v2.13)
 - [v2.12](https://github.com/openservicebrokerapi/servicebroker/tree/v2.12)
 - [v2.11](https://github.com/openservicebrokerapi/servicebroker/tree/v2.11)
 

--- a/v2/bind.go
+++ b/v2/bind.go
@@ -12,6 +12,7 @@ type bindRequestBody struct {
 	PlanID       string                 `json:"plan_id"`
 	Parameters   map[string]interface{} `json:"parameters,omitempty"`
 	BindResource map[string]interface{} `json:"bind_resource,omitempty"`
+	Context      map[string]interface{} `json:"context,omitempty"`
 }
 
 const (
@@ -30,6 +31,10 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 		ServiceID:  r.ServiceID,
 		PlanID:     r.PlanID,
 		Parameters: r.Parameters,
+	}
+
+	if c.APIVersion.AtLeast(Version2_13()) {
+		requestBody.Context = r.Context
 	}
 
 	if r.BindResource != nil {

--- a/v2/bind_test.go
+++ b/v2/bind_test.go
@@ -150,7 +150,7 @@ func TestBind(t *testing.T) {
 			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
-			name: "context included if API version >= 2.13",
+			name:    "context included if API version >= 2.13",
 			version: Version2_13(),
 			request: contextBindRequest(),
 			httpChecks: httpChecks{
@@ -163,7 +163,7 @@ func TestBind(t *testing.T) {
 			expectedResponse: successBindResponse(),
 		},
 		{
-			name: "context not included if API version < 2.13",
+			name:    "context not included if API version < 2.13",
 			version: Version2_12(),
 			request: contextBindRequest(),
 			httpChecks: httpChecks{

--- a/v2/client.go
+++ b/v2/client.go
@@ -120,7 +120,7 @@ const (
 // message body, and executes the request, returning an http.Response or an
 // error.  Errors returned from this function represent http-layer errors and
 // not errors in the Open Service Broker API.
-func (c *client) prepareAndDo(method, URL string, params map[string]string, body interface{}, originatingIdentity *AlphaOriginatingIdentity) (*http.Response, error) {
+func (c *client) prepareAndDo(method, URL string, params map[string]string, body interface{}, originatingIdentity *OriginatingIdentity) (*http.Response, error) {
 	var bodyReader io.Reader
 
 	if body != nil {
@@ -152,7 +152,7 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 		}
 	}
 
-	if c.EnableAlphaFeatures && originatingIdentity != nil {
+	if c.APIVersion.AtLeast(Version2_13()) && originatingIdentity != nil {
 		headerValue, err := buildOriginatingIdentityHeaderValue(originatingIdentity)
 		if err != nil {
 			return nil, err
@@ -215,7 +215,7 @@ func (c *client) handleFailureResponse(response *http.Response) error {
 	}
 }
 
-func buildOriginatingIdentityHeaderValue(i *AlphaOriginatingIdentity) (string, error) {
+func buildOriginatingIdentityHeaderValue(i *OriginatingIdentity) (string, error) {
 	if i == nil {
 		return "", nil
 	}

--- a/v2/client_test.go
+++ b/v2/client_test.go
@@ -23,7 +23,7 @@ const (
 	testOriginatingIdentityHeaderValue = "fakeplatform eyJ1c2VyIjoibmFtZSJ9"
 )
 
-var testOriginatingIdentity = &AlphaOriginatingIdentity{
+var testOriginatingIdentity = &OriginatingIdentity{
 	Platform: testOriginatingIdentityPlatform,
 	Value:    testOriginatingIdentityValue,
 }
@@ -181,7 +181,7 @@ func TestBuildOriginatingIdentityHeaderValue(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		originatingIdentity := &AlphaOriginatingIdentity{
+		originatingIdentity := &OriginatingIdentity{
 			Platform: tc.platform,
 			Value:    tc.value,
 		}

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -40,8 +40,9 @@ func successDeprovisionResponseAsync() *DeprovisionResponse {
 func TestDeprovisionInstance(t *testing.T) {
 	cases := []struct {
 		name                string
+		version             APIVersion
 		enableAlpha         bool
-		originatingIdentity *AlphaOriginatingIdentity
+		originatingIdentity *OriginatingIdentity
 		request             *DeprovisionRequest
 		httpChecks          httpChecks
 		httpReaction        httpReaction
@@ -149,7 +150,7 @@ func TestDeprovisionInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity included",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: testOriginatingIdentity,
 			httpReaction: httpReaction{
 				status: http.StatusOK,
@@ -166,7 +167,7 @@ func TestDeprovisionInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity excluded",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: nil,
 			httpReaction: httpReaction{
 				status: http.StatusOK,
@@ -182,8 +183,8 @@ func TestDeprovisionInstance(t *testing.T) {
 			expectedResponse: successDeprovisionResponse(),
 		},
 		{
-			name:                "originating identity not sent unless alpha enabled",
-			enableAlpha:         false,
+			name:                "originating identity not sent unless API version >= 2.13",
+			version:             Version2_12(),
 			originatingIdentity: testOriginatingIdentity,
 			httpReaction: httpReaction{
 				status: http.StatusOK,
@@ -211,8 +212,11 @@ func TestDeprovisionInstance(t *testing.T) {
 			tc.httpChecks.URL = "/v2/service_instances/test-instance-id"
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.DeprovisionInstance(tc.request)
 

--- a/v2/get_catalog.go
+++ b/v2/get_catalog.go
@@ -20,10 +20,10 @@ func (c *client) GetCatalog() (*CatalogResponse, error) {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
-		if !c.EnableAlphaFeatures {
+		if !c.APIVersion.AtLeast(Version2_13()) {
 			for ii := range catalogResponse.Services {
 				for jj := range catalogResponse.Services[ii].Plans {
-					catalogResponse.Services[ii].Plans[jj].AlphaParameterSchemas = nil
+					catalogResponse.Services[ii].Plans[jj].ParameterSchemas = nil
 				}
 			}
 		}

--- a/v2/get_catalog_test.go
+++ b/v2/get_catalog_test.go
@@ -249,8 +249,8 @@ func TestGetCatalog(t *testing.T) {
 			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
-			name:        "schemas included if API version >= 2.13",
-			version:      Version2_13(),
+			name:    "schemas included if API version >= 2.13",
+			version: Version2_13(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,
@@ -258,8 +258,8 @@ func TestGetCatalog(t *testing.T) {
 			expectedResponse: alphaParameterCatalogResponse(),
 		},
 		{
-			name: "schemas not included if API version < 2.13",
-			version:      Version2_12(),
+			name:    "schemas not included if API version < 2.13",
+			version: Version2_12(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,

--- a/v2/get_catalog_test.go
+++ b/v2/get_catalog_test.go
@@ -166,21 +166,21 @@ const alphaParameterSchemaCatalogBytes = `{
 
 func alphaParameterCatalogResponse() *CatalogResponse {
 	catalog := okCatalogResponse()
-	catalog.Services[0].Plans[0].AlphaParameterSchemas = &AlphaParameterSchemas{
-		ServiceInstances: &AlphaServiceInstanceSchema{
-			Create: &AlphaInputParameters{
+	catalog.Services[0].Plans[0].ParameterSchemas = &ParameterSchemas{
+		ServiceInstances: &ServiceInstanceSchema{
+			Create: &InputParameters{
 				Parameters: map[string]interface{}{
 					"foo": "bar",
 				},
 			},
-			Update: &AlphaInputParameters{
+			Update: &InputParameters{
 				Parameters: map[string]interface{}{
 					"baz": "zap",
 				},
 			},
 		},
-		ServiceBindings: &AlphaServiceBindingSchema{
-			Create: &AlphaInputParameters{
+		ServiceBindings: &ServiceBindingSchema{
+			Create: &InputParameters{
 				Parameters: map[string]interface{}{
 					"zoo": "blu",
 				},
@@ -194,6 +194,7 @@ func alphaParameterCatalogResponse() *CatalogResponse {
 func TestGetCatalog(t *testing.T) {
 	cases := []struct {
 		name               string
+		version            APIVersion
 		enableAlpha        bool
 		httpReaction       httpReaction
 		expectedResponse   *CatalogResponse
@@ -248,8 +249,8 @@ func TestGetCatalog(t *testing.T) {
 			expectedErr: testHTTPStatusCodeError(),
 		},
 		{
-			name:        "alpha enabled - schemas",
-			enableAlpha: true,
+			name:        "schemas included if API version >= 2.13",
+			version:      Version2_13(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,
@@ -257,7 +258,8 @@ func TestGetCatalog(t *testing.T) {
 			expectedResponse: alphaParameterCatalogResponse(),
 		},
 		{
-			name: "alpha disabled - schemas",
+			name: "schemas not included if API version < 2.13",
+			version:      Version2_12(),
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   alphaParameterSchemaCatalogBytes,
@@ -271,8 +273,11 @@ func TestGetCatalog(t *testing.T) {
 			URL: "/v2/catalog",
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, httpChecks, tc.httpReaction)
 
 		response, err := klient.GetCatalog()
 

--- a/v2/types.go
+++ b/v2/types.go
@@ -121,11 +121,11 @@ type AlphaInputParameters struct {
 	Parameters interface{} `json:"parameters,omitempty"`
 }
 
-// AlphaOriginatingIdentity is ALPHA and may change or disappear at any time.
+// OriginatingIdentity requires a client version >=2.13.
 //
-// AlphaOriginatingIdentity is used to pass to the broker service an identity from
+// OriginatingIdentity is used to pass to the broker service an identity from
 // the platform
-type AlphaOriginatingIdentity struct {
+type OriginatingIdentity struct {
 	// The name of the platform to which the user belongs
 	Platform string
 	// A serialized JSON object that describes the user in a way that makes
@@ -168,7 +168,7 @@ type ProvisionRequest struct {
 	// 2.12 of the OSB API and is only sent for versions 2.12 or later.
 	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
 
 // ProvisionResponse is sent in response to a provision call
@@ -210,7 +210,7 @@ type UpdateInstanceRequest struct {
 	// for an instance.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 
 	// The OSB API also has a field called `previous_values` that contains:
 	// OrgID
@@ -251,7 +251,7 @@ type DeprovisionRequest struct {
 	// PlanID is the ID of the plan the instance is provisioned from.
 	PlanID string `json:"plan_id"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
 
 // DeprovisionResponse represents a broker's response to a deprovision request.
@@ -281,7 +281,7 @@ type LastOperationRequest struct {
 	// supplied in the response to the original request.
 	OperationKey *OperationKey `json:"operation,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
 
 // LastOperationResponse represents the broker response with the state of a
@@ -326,7 +326,7 @@ type BindRequest struct {
 	// Parameters is configuration parameters for the binding.  Optional.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
 
 // BindResource contains data for platform resources associated with a
@@ -367,7 +367,7 @@ type UnbindRequest struct {
 	// PlanID is the ID of the plan the instance was provisioned from.
 	PlanID string `json:"plan_id"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
-	OriginatingIdentity *AlphaOriginatingIdentity `json:"originatingIdentity,omitempty"`
+	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }
 
 // UnbindResponse represents a broker's response to an UnbindRequest.

--- a/v2/types.go
+++ b/v2/types.go
@@ -76,48 +76,46 @@ type Plan struct {
 	// facing content and display instructions.  Metadata may contain
 	// platform-conventional values.  Optional.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	// AlphaParameterSchemas is ALPHA and may change or disappear at any time.
-	// AlphaParameterSchemas will only be provided if alpha features are
-	// enabled.
+	// ParameterSchemas requires a client version >=2.13.
 	//
-	// AlphaParameterSchemas is a set of optional JSONSchemas that describe
+	// ParameterSchemas is a set of optional JSONSchemas that describe
 	// the expected parameters for creation and update of instances and
 	// creation of bindings.
-	AlphaParameterSchemas *AlphaParameterSchemas `json:"schemas,omitempty"`
+	ParameterSchemas *ParameterSchemas `json:"schemas,omitempty"`
 }
 
-// AlphaParameterSchemas is ALPHA and may change or disappear at any time.
+// ParameterSchemas requires a client version >=2.13.
 //
-// AlphaParameterSchemas is a set of optional JSONSchemas that describe
+// ParameterSchemas is a set of optional JSONSchemas that describe
 // the expected parameters for creation and update of instances and
 // creation of bindings.
-type AlphaParameterSchemas struct {
-	ServiceInstances *AlphaServiceInstanceSchema `json:"service_instance,omitempty"`
-	ServiceBindings  *AlphaServiceBindingSchema  `json:"service_binding,omitempty"`
+type ParameterSchemas struct {
+	ServiceInstances *ServiceInstanceSchema `json:"service_instance,omitempty"`
+	ServiceBindings  *ServiceBindingSchema  `json:"service_binding,omitempty"`
 }
 
-// AlphaServiceInstanceSchema is ALPHA and may change or disappear at any time.
+// ServiceInstanceSchema requires a client version >=2.13.
 //
-// AlphaServiceInstanceSchema represents a plan's schemas for creation and
+// ServiceInstanceSchema represents a plan's schemas for creation and
 // update of an API resource.
-type AlphaServiceInstanceSchema struct {
-	Create *AlphaInputParameters `json:"create,omitempty"`
-	Update *AlphaInputParameters `json:"update,omitempty"`
+type ServiceInstanceSchema struct {
+	Create *InputParameters `json:"create,omitempty"`
+	Update *InputParameters `json:"update,omitempty"`
 }
 
-// AlphaServiceBindingSchema is ALPHA and may change or disappear at any time.
+// ServiceBindingSchema requires a client version >=2.13.
 //
-// AlphaServiceBindingSchema represents a plan's schemas for the parameters
+// ServiceBindingSchema represents a plan's schemas for the parameters
 // accepted for binding creation.
-type AlphaServiceBindingSchema struct {
-	Create *AlphaInputParameters `json:"create,omitempty"`
+type ServiceBindingSchema struct {
+	Create *InputParameters `json:"create,omitempty"`
 }
 
-// AlphaInputParameters is ALPHA and may change or disappear at any time.
+// InputParameters requires a client version >=2.13.
 //
-// AlphaInputParameters represents a schema for input parameters for creation or
+// InputParameters represents a schema for input parameters for creation or
 // update of an API resource.
-type AlphaInputParameters struct {
+type InputParameters struct {
 	Parameters interface{} `json:"parameters,omitempty"`
 }
 

--- a/v2/types.go
+++ b/v2/types.go
@@ -76,7 +76,7 @@ type Plan struct {
 	// facing content and display instructions.  Metadata may contain
 	// platform-conventional values.  Optional.
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	// ParameterSchemas requires a client version >=2.13.
+	// ParameterSchemas requires a client API version >=2.13.
 	//
 	// ParameterSchemas is a set of optional JSONSchemas that describe
 	// the expected parameters for creation and update of instances and
@@ -84,7 +84,7 @@ type Plan struct {
 	ParameterSchemas *ParameterSchemas `json:"schemas,omitempty"`
 }
 
-// ParameterSchemas requires a client version >=2.13.
+// ParameterSchemas requires a client API version >=2.13.
 //
 // ParameterSchemas is a set of optional JSONSchemas that describe
 // the expected parameters for creation and update of instances and
@@ -94,7 +94,7 @@ type ParameterSchemas struct {
 	ServiceBindings  *ServiceBindingSchema  `json:"service_binding,omitempty"`
 }
 
-// ServiceInstanceSchema requires a client version >=2.13.
+// ServiceInstanceSchema requires a client API version >=2.13.
 //
 // ServiceInstanceSchema represents a plan's schemas for creation and
 // update of an API resource.
@@ -103,7 +103,7 @@ type ServiceInstanceSchema struct {
 	Update *InputParameters `json:"update,omitempty"`
 }
 
-// ServiceBindingSchema requires a client version >=2.13.
+// ServiceBindingSchema requires a client API version >=2.13.
 //
 // ServiceBindingSchema represents a plan's schemas for the parameters
 // accepted for binding creation.
@@ -111,7 +111,7 @@ type ServiceBindingSchema struct {
 	Create *InputParameters `json:"create,omitempty"`
 }
 
-// InputParameters requires a client version >=2.13.
+// InputParameters requires a client API version >=2.13.
 //
 // InputParameters represents a schema for input parameters for creation or
 // update of an API resource.
@@ -119,7 +119,7 @@ type InputParameters struct {
 	Parameters interface{} `json:"parameters,omitempty"`
 }
 
-// OriginatingIdentity requires a client version >=2.13.
+// OriginatingIdentity requires a client API version >=2.13.
 //
 // OriginatingIdentity is used to pass to the broker service an identity from
 // the platform
@@ -161,9 +161,10 @@ type ProvisionRequest struct {
 	// Parameters is a set of configuration options for the service instance.
 	// Optional.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// Context requires a client API version >= 2.12.
+	//
 	// Context is platform-specific contextual information under which the
-	// service instance is to be provisioned.  Context was added in version
-	// 2.12 of the OSB API and is only sent for versions 2.12 or later.
+	// service instance is to be provisioned.
 	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`

--- a/v2/types.go
+++ b/v2/types.go
@@ -324,6 +324,11 @@ type BindRequest struct {
 	BindResource *BindResource `json:"bind_resource,omitempty"`
 	// Parameters is configuration parameters for the binding.  Optional.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// Context requires a client API version >= 2.13.
+	//
+	// Context is platform-specific contextual information under which the
+	// service binding is to be created.
+	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
 }

--- a/v2/unbind_test.go
+++ b/v2/unbind_test.go
@@ -24,8 +24,9 @@ func successUnbindResponse() *UnbindResponse {
 func TestUnbind(t *testing.T) {
 	cases := []struct {
 		name                string
+		version             APIVersion
 		enableAlpha         bool
-		originatingIdentity *AlphaOriginatingIdentity
+		originatingIdentity *OriginatingIdentity
 		request             *UnbindRequest
 		httpChecks          httpChecks
 		httpReaction        httpReaction
@@ -83,7 +84,7 @@ func TestUnbind(t *testing.T) {
 		},
 		{
 			name:                "originating identity included",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: testOriginatingIdentityHeaderValue}},
 			httpReaction: httpReaction{
@@ -94,7 +95,7 @@ func TestUnbind(t *testing.T) {
 		},
 		{
 			name:                "originating identity excluded",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: nil,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -104,8 +105,8 @@ func TestUnbind(t *testing.T) {
 			expectedResponse: successUnbindResponse(),
 		},
 		{
-			name:                "originating identity not sent unless alpha enabled",
-			enableAlpha:         false,
+			name:                "originating identity not sent unless API version >= 2.13",
+			version:             Version2_12(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -133,8 +134,11 @@ func TestUnbind(t *testing.T) {
 			tc.httpChecks.params[planIDKey] = testPlanID
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.Unbind(tc.request)
 

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -40,8 +40,9 @@ func successUpdateInstanceResponseAsync() *UpdateInstanceResponse {
 func TestUpdateInstanceInstance(t *testing.T) {
 	cases := []struct {
 		name                string
+		version             APIVersion
 		enableAlpha         bool
-		originatingIdentity *AlphaOriginatingIdentity
+		originatingIdentity *OriginatingIdentity
 		request             *UpdateInstanceRequest
 		httpChecks          httpChecks
 		httpReaction        httpReaction
@@ -135,7 +136,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity included",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: testOriginatingIdentityHeaderValue}},
 			httpReaction: httpReaction{
@@ -146,7 +147,7 @@ func TestUpdateInstanceInstance(t *testing.T) {
 		},
 		{
 			name:                "originating identity excluded",
-			enableAlpha:         true,
+			version:             Version2_13(),
 			originatingIdentity: nil,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -156,8 +157,8 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			expectedResponse: successUpdateInstanceResponse(),
 		},
 		{
-			name:                "originating identity not sent unless alpha enabled",
-			enableAlpha:         false,
+			name:                "originating identity not sent unless API version >= 2.13",
+			version:             Version2_12(),
 			originatingIdentity: testOriginatingIdentity,
 			httpChecks:          httpChecks{headers: map[string]string{OriginatingIdentityHeader: ""}},
 			httpReaction: httpReaction{
@@ -183,8 +184,11 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			tc.httpChecks.body = "{\"service_id\":\"test-service-id\",\"plan_id\":\"test-plan-id\"}"
 		}
 
-		version := Version2_11()
-		klient := newTestClient(t, tc.name, version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
+		if tc.version.label == "" {
+			tc.version = Version2_11()
+		}
+
+		klient := newTestClient(t, tc.name, tc.version, tc.enableAlpha, tc.httpChecks, tc.httpReaction)
 
 		response, err := klient.UpdateInstance(tc.request)
 

--- a/v2/version.go
+++ b/v2/version.go
@@ -26,20 +26,29 @@ const (
 	// internalAPIVersion2_12 represents the 2.12 version of the Open Service
 	// Broker API.
 	internalAPIVersion2_12 = "2.12"
-)
 
-//Version2_12 returns an APIVersion struct with the internal API version set to "2.12"
-func Version2_12() APIVersion {
-	return APIVersion{label: internalAPIVersion2_12, order: 1}
-}
+	// internalAPIVersion2_13 represents the 2.13 version of the Open Service
+	// Broker API.
+	internalAPIVersion2_13 = "2.13"
+)
 
 //Version2_11 returns an APIVersion struct with the internal API version set to "2.11"
 func Version2_11() APIVersion {
 	return APIVersion{label: internalAPIVersion2_11, order: 0}
 }
 
+//Version2_12 returns an APIVersion struct with the internal API version set to "2.12"
+func Version2_12() APIVersion {
+	return APIVersion{label: internalAPIVersion2_12, order: 1}
+}
+
+//Version2_13 returns an APIVersion struct with the internal API version set to "2.13"
+func Version2_13() APIVersion {
+	return APIVersion{label: internalAPIVersion2_13, order: 2}
+}
+
 // LatestAPIVersion returns the latest supported API version in the current
 // release of this library.
 func LatestAPIVersion() APIVersion {
-	return Version2_12()
+	return Version2_13()
 }

--- a/v2/version_test.go
+++ b/v2/version_test.go
@@ -19,7 +19,7 @@ func TestAtLeast(t *testing.T) {
 
 func TestLatestAPIVersion(t *testing.T) {
 
-	if LatestAPIVersion() != Version2_12() {
-		t.Error("Unexpected Latest API Verion--expected 2.12")
+	if LatestAPIVersion() != Version2_13() {
+		t.Error("Unexpected Latest API Version--expected 2.13")
 	}
 }


### PR DESCRIPTION
- Adds a version 2.13 API Version to the client
- Graduates OriginatingIdentity and ParameterSchemas from alpha and gates them on API Version >= 2.13
- Adds Context field to bind request

Closes: #81 