### PR TITLE
initial exposure of Prometheus metrics

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -177,7 +177,9 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 }
 
 func (c *client) doRequest(request *http.Request) (*http.Response, error) {
-	return c.httpClient.Do(request)
+	response, error := c.httpClient.Do(request)
+	updateMetrics(c, response, error)
+	return response, error
 }
 
 // unmarshalResponse unmartials the response body of the given response into
@@ -193,11 +195,8 @@ func (c *client) unmarshalResponse(response *http.Response, obj interface{}) err
 	}
 
 	err = json.Unmarshal(body, obj)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // handleFailureResponse returns an HTTPStatusCodeError for the given

--- a/v2/metrics.go
+++ b/v2/metrics.go
@@ -1,0 +1,56 @@
+package v2
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var registerMetrics sync.Once
+
+// Metrics are identified in Prometheus by concatinating Namespace, Subsystem and Name
+// ex servicecatalog_osbclient_request_count
+const (
+	CatalogNamespace = "servicecatalog"
+	OSBSubsystem     = "osbclient"
+)
+
+var (
+	requests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: CatalogNamespace,
+			Subsystem: OSBSubsystem,
+			Name:      "request_count",
+			Help:      "Cumulative number of requests made to the specified Service Broker.",
+		},
+		[]string{"broker"},
+	)
+	responses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: CatalogNamespace,
+			Subsystem: OSBSubsystem,
+			Name:      "response_by_status_count",
+			Help:      "Cumulative number of responses from the specified Service Broker grouped by status.",
+		},
+		[]string{"broker", "status"},
+	)
+)
+
+func init() {
+	registerMetrics.Do(func() {
+		prometheus.MustRegister(requests)
+		prometheus.MustRegister(responses)
+	})
+}
+
+func updateMetrics(c *client, response *http.Response, lastRequestError error) {
+	requests.WithLabelValues(c.Name).Inc()
+
+	if lastRequestError != nil {
+		responses.WithLabelValues(c.Name, "client-error").Inc()
+	} else {
+		responses.WithLabelValues(c.Name, strconv.Itoa(response.StatusCode/100*100)).Inc()
+	}
+}


### PR DESCRIPTION
In support of https://github.com/kubernetes-incubator/service-catalog/issues/677, expose some metrics to Prometheus which can then be polled and reported on.  Initial metrics to get the proof of concept moving forward, this instruments total request count and error/status count all grouped by Service Broker name. 