### PR TITLE
Add PreviousValues to UpdateInstanceRequest

### DIFF
--- a/v2/types.go
+++ b/v2/types.go
@@ -217,6 +217,8 @@ type UpdateInstanceRequest struct {
 	// unset, indicates that the client does not wish to update the parameters
 	// for an instance.
 	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	// Previous values contains information about the service instance prior to the update
+	PreviousValues *PreviousValues `json:"previous_values,omitempty"`
 	// Context requires a client API version >= 2.12.
 	//
 	// Context is platform-specific contextual information under which the
@@ -224,17 +226,23 @@ type UpdateInstanceRequest struct {
 	Context map[string]interface{} `json:"context,omitempty"`
 	// OriginatingIdentity is the identity on the platform of the user making this request.
 	OriginatingIdentity *OriginatingIdentity `json:"originatingIdentity,omitempty"`
+}
 
-	// The OSB API also has a field called `previous_values` that contains:
-	// OrgID
-	// SpaceID
-	// ServiceID
-	// PlanID
-	//
-	// ...but those fields seem to be a relic of some API design mistakes in
-	// the past.  As such, this client library does not currently support
-	// them.  I will happily change this if someone can present a specific
-	// example of a broker that requires these fields to be sent.
+// PreviousValues represents information about the service instance prior to the update
+type PreviousValues struct {
+	// ID of the plan prior to the update. If present, MUST be a non-empty string.
+	PlanID string `json:"plan_id,omitempty"`
+	// Deprecated; determined to be unnecessary as the value is immutable. ID of the service
+	// for the service instance. If present, MUST be a non-empty string
+	ServiceID string `json:"service_id,omitempty"`
+	// Deprecated; Organization for the service instance MUST be provided by platforms in the
+	// top-level field context. ID of the organization specified for the service instance.
+	// If present, MUST be a non-empty string.
+	OrgID string `json:"organization_id,omitempty"`
+	// Deprecated; Space for the service instance MUST be provided by platforms in the top-level
+	// field context. ID of the space specified for the service instance. If present, MUST be
+	// a non-empty string.
+	SpaceID string `json:"space_id,omitempty"`
 }
 
 // UpdateInstanceResponse represents a broker's response to an update instance

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -8,13 +8,11 @@ import (
 // internal message body types
 
 type updateInstanceRequestBody struct {
-	ServiceID  string                 `json:"service_id"`
-	PlanID     *string                `json:"plan_id,omitempty"`
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
-	Context    map[string]interface{} `json:"context,omitempty"`
-
-	// Note: this client does not currently support the 'previous_values'
-	// field of this request body.
+	ServiceID      string                 `json:"service_id"`
+	PlanID         *string                `json:"plan_id,omitempty"`
+	Parameters     map[string]interface{} `json:"parameters,omitempty"`
+	Context        map[string]interface{} `json:"context,omitempty"`
+	PreviousValues *PreviousValues        `json:"previous_values,omitempty"`
 }
 
 func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceResponse, error) {
@@ -29,9 +27,10 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	}
 
 	requestBody := &updateInstanceRequestBody{
-		ServiceID:  r.ServiceID,
-		PlanID:     r.PlanID,
-		Parameters: r.Parameters,
+		ServiceID:      r.ServiceID,
+		PlanID:         r.PlanID,
+		Parameters:     r.Parameters,
+		PreviousValues: r.PreviousValues,
 	}
 
 	if c.APIVersion.AtLeast(Version2_12()) {
@@ -42,7 +41,6 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	if err != nil {
 		return nil, err
 	}
-
 	switch response.StatusCode {
 	case http.StatusOK:
 		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -41,6 +41,8 @@ func successUpdateInstanceResponseAsync() *UpdateInstanceResponse {
 
 const contextUpdateInstanceRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","context":{"foo":"bar"}}`
 
+const previousValuesUpdateInstanceRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id","previous_values":{"plan_id":"previous-plan-id"}}`
+
 func TestUpdateInstanceInstance(t *testing.T) {
 	cases := []struct {
 		name                string
@@ -168,6 +170,24 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			}(),
 			httpChecks: httpChecks{
 				body: successUpdateInstanceRequestBody,
+			},
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBody,
+			},
+			expectedResponse: successUpdateInstanceResponse(),
+		},
+		{
+			name: "previous values",
+			request: func() *UpdateInstanceRequest {
+				r := defaultUpdateInstanceRequest()
+				r.PreviousValues = &PreviousValues{
+					PlanID: "previous-plan-id",
+				}
+				return r
+			}(),
+			httpChecks: httpChecks{
+				body: previousValuesUpdateInstanceRequestBody,
 			},
 			httpReaction: httpReaction{
 				status: http.StatusOK,


### PR DESCRIPTION
This PR is for #94 , intended to pass `previous_values` for updating instance as per the spec: https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#updating-a-service-instance

`ServiceID`, `OrgID`, `SpaceID` are deprecated, but `PlanID` is not. Leave all deprecated fields for now if there's no objection.

cc @frodenas