### PR TITLE
Allow dashboard_url in response to update service instance

### DIFF
--- a/v2/types.go
+++ b/v2/types.go
@@ -251,6 +251,10 @@ type UpdateInstanceResponse struct {
 	// Async indicates whether the broker is handling the update request
 	// asynchronously.
 	Async bool `json:"async"`
+	// DashboardURL is an ALPHA API attribute and may change. Alpha
+	// features must be enabled and the client must be using the latest
+	// API Version in order to use this.
+	//
 	// DashboardURL is the URL of a web-based management user interface for
 	// the service instance.
 	DashboardURL *string `json:"dashboard_url,omitempty"`

--- a/v2/types.go
+++ b/v2/types.go
@@ -251,6 +251,9 @@ type UpdateInstanceResponse struct {
 	// Async indicates whether the broker is handling the update request
 	// asynchronously.
 	Async bool `json:"async"`
+	// DashboardURL is the URL of a web-based management user interface for
+	// the service instance.
+	DashboardURL *string `json:"dashboard_url,omitempty"`
 	// OperationKey is an extra identifier supplied by the broker to identify
 	// asynchronous operations.
 	OperationKey *OperationKey `json:"operation,omitempty"`

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -15,6 +15,11 @@ type updateInstanceRequestBody struct {
 	PreviousValues *PreviousValues        `json:"previous_values,omitempty"`
 }
 
+type updateInstanceResponseBody struct {
+	DashboardURL *string `json:"dashboard_url"`
+	Operation    *string `json:"operation"`
+}
+
 func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceResponse, error) {
 	if err := validateUpdateInstanceRequest(r); err != nil {
 		return nil, err
@@ -43,11 +48,25 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	}
 	switch response.StatusCode {
 	case http.StatusOK:
-		if err := c.unmarshalResponse(response, &struct{}{}); err != nil {
+		responseBodyObj := &updateInstanceResponseBody{}
+		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
-		return &UpdateInstanceResponse{}, nil
+		var opPtr *OperationKey
+		if responseBodyObj.Operation != nil {
+			opStr := *responseBodyObj.Operation
+			op := OperationKey(opStr)
+			opPtr = &op
+		}
+
+		userResponse := &UpdateInstanceResponse{
+			Async:        false,
+			DashboardURL: responseBodyObj.DashboardURL,
+			OperationKey: opPtr,
+		}
+
+		return userResponse, nil
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
 			// If the client did not signify that it could handle asynchronous
@@ -55,7 +74,7 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 			return nil, c.handleFailureResponse(response)
 		}
 
-		responseBodyObj := &asyncSuccessResponseBody{}
+		responseBodyObj := &updateInstanceResponseBody{}
 		if err := c.unmarshalResponse(response, responseBodyObj); err != nil {
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
@@ -69,6 +88,7 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 
 		userResponse := &UpdateInstanceResponse{
 			Async:        true,
+			DashboardURL: responseBodyObj.DashboardURL,
 			OperationKey: opPtr,
 		}
 

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -53,17 +53,12 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 			return nil, HTTPStatusCodeError{StatusCode: response.StatusCode, ResponseError: err}
 		}
 
-		var opPtr *OperationKey
-		if responseBodyObj.Operation != nil {
-			opStr := *responseBodyObj.Operation
-			op := OperationKey(opStr)
-			opPtr = &op
-		}
-
 		userResponse := &UpdateInstanceResponse{
 			Async:        false,
-			DashboardURL: responseBodyObj.DashboardURL,
-			OperationKey: opPtr,
+			OperationKey: nil,
+		}
+		if c.validateAlphaAPIMethodsAllowed() == nil {
+			userResponse.DashboardURL = responseBodyObj.DashboardURL
 		}
 
 		return userResponse, nil
@@ -88,8 +83,10 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 
 		userResponse := &UpdateInstanceResponse{
 			Async:        true,
-			DashboardURL: responseBodyObj.DashboardURL,
 			OperationKey: opPtr,
+		}
+		if c.validateAlphaAPIMethodsAllowed() == nil {
+			userResponse.DashboardURL = responseBodyObj.DashboardURL
 		}
 
 		// TODO: fix op key handling

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -54,7 +54,7 @@ func successUpdateInstanceResponseAsync() *UpdateInstanceResponse {
 func successUpdateInstanceResponeAsyncWithDashboard() *UpdateInstanceResponse {
 	r := successUpdateInstanceResponseAsync()
 	url := "http://updated.com"
-	r.DashboardURL = &url
+	r.DashboardURL = strPtr(url)
 	return r
 }
 
@@ -93,14 +93,6 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			expectedResponse: successUpdateInstanceResponse(),
 		},
 		{
-			name: "success with updated dashboard url - ok",
-			httpReaction: httpReaction{
-				status: http.StatusOK,
-				body:   successUpdateInstanceResponseBodyWithNewDashboardURL,
-			},
-			expectedResponse: successUpdateInstanceResponseWithDashboard(),
-		},
-		{
 			name:    "success - async",
 			request: defaultAsyncUpdateInstanceRequest(),
 			httpChecks: httpChecks{
@@ -113,20 +105,6 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				body:   successAsyncUpdateInstanceResponseBody,
 			},
 			expectedResponse: successUpdateInstanceResponseAsync(),
-		},
-		{
-			name:    "success with updated dashboard url - async",
-			request: defaultAsyncUpdateInstanceRequest(),
-			httpChecks: httpChecks{
-				params: map[string]string{
-					AcceptsIncomplete: "true",
-				},
-			},
-			httpReaction: httpReaction{
-				status: http.StatusAccepted,
-				body:   successAsyncUpdateInstanceResponseBodyWithNewDashboardURL,
-			},
-			expectedResponse: successUpdateInstanceResponeAsyncWithDashboard(),
 		},
 		{
 			name:    "accepted with malformed response",
@@ -266,6 +244,52 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			httpReaction: httpReaction{
 				status: http.StatusOK,
 				body:   successUpdateInstanceResponseBody,
+			},
+			expectedResponse: successUpdateInstanceResponse(),
+		},
+		{
+			name:        "success with updated dashboard url - ok if alpha API features are enabled",
+			version:     LatestAPIVersion(),
+			enableAlpha: true,
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBodyWithNewDashboardURL,
+			},
+			expectedResponse: successUpdateInstanceResponseWithDashboard(),
+		},
+		{
+			name:        "success with updated dashboard url - async if alpha API features are enabled",
+			version:     LatestAPIVersion(),
+			enableAlpha: true,
+			request:     defaultAsyncUpdateInstanceRequest(),
+			httpChecks: httpChecks{
+				params: map[string]string{
+					AcceptsIncomplete: "true",
+				},
+			},
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncUpdateInstanceResponseBodyWithNewDashboardURL,
+			},
+			expectedResponse: successUpdateInstanceResponeAsyncWithDashboard(),
+		},
+		{
+			name:        "dashboard url not sent unless alpha API features enabled",
+			version:     LatestAPIVersion(),
+			enableAlpha: false,
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBodyWithNewDashboardURL,
+			},
+			expectedResponse: successUpdateInstanceResponse(),
+		},
+		{
+			name:        "dashboard url not sent unless latest version of the API is used",
+			version:     Version2_12(),
+			enableAlpha: true,
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBodyWithNewDashboardURL,
 			},
 			expectedResponse: successUpdateInstanceResponse(),
 		},

--- a/v2/update_instance_test.go
+++ b/v2/update_instance_test.go
@@ -23,6 +23,7 @@ func defaultAsyncUpdateInstanceRequest() *UpdateInstanceRequest {
 const successUpdateInstanceRequestBody = `{"service_id":"test-service-id","plan_id":"test-plan-id"}`
 
 const successUpdateInstanceResponseBody = `{}`
+const successUpdateInstanceResponseBodyWithNewDashboardURL = `{"dashboard_url":"http://updated.com"}`
 
 func successUpdateInstanceResponse() *UpdateInstanceResponse {
 	return &UpdateInstanceResponse{}
@@ -31,11 +32,29 @@ func successUpdateInstanceResponse() *UpdateInstanceResponse {
 const successAsyncUpdateInstanceResponseBody = `{
   "operation": "test-operation-key"
 }`
+const successAsyncUpdateInstanceResponseBodyWithNewDashboardURL = `{
+	"dashboard_url": "http://updated.com",
+	"operation": "test-operation-key"
+}`
+
+func successUpdateInstanceResponseWithDashboard() *UpdateInstanceResponse {
+	r := successUpdateInstanceResponse()
+	url := "http://updated.com"
+	r.DashboardURL = &url
+	return r
+}
 
 func successUpdateInstanceResponseAsync() *UpdateInstanceResponse {
 	r := successUpdateInstanceResponse()
 	r.Async = true
 	r.OperationKey = &testOperation
+	return r
+}
+
+func successUpdateInstanceResponeAsyncWithDashboard() *UpdateInstanceResponse {
+	r := successUpdateInstanceResponseAsync()
+	url := "http://updated.com"
+	r.DashboardURL = &url
 	return r
 }
 
@@ -74,6 +93,14 @@ func TestUpdateInstanceInstance(t *testing.T) {
 			expectedResponse: successUpdateInstanceResponse(),
 		},
 		{
+			name: "success with updated dashboard url - ok",
+			httpReaction: httpReaction{
+				status: http.StatusOK,
+				body:   successUpdateInstanceResponseBodyWithNewDashboardURL,
+			},
+			expectedResponse: successUpdateInstanceResponseWithDashboard(),
+		},
+		{
 			name:    "success - async",
 			request: defaultAsyncUpdateInstanceRequest(),
 			httpChecks: httpChecks{
@@ -86,6 +113,20 @@ func TestUpdateInstanceInstance(t *testing.T) {
 				body:   successAsyncUpdateInstanceResponseBody,
 			},
 			expectedResponse: successUpdateInstanceResponseAsync(),
+		},
+		{
+			name:    "success with updated dashboard url - async",
+			request: defaultAsyncUpdateInstanceRequest(),
+			httpChecks: httpChecks{
+				params: map[string]string{
+					AcceptsIncomplete: "true",
+				},
+			},
+			httpReaction: httpReaction{
+				status: http.StatusAccepted,
+				body:   successAsyncUpdateInstanceResponseBodyWithNewDashboardURL,
+			},
+			expectedResponse: successUpdateInstanceResponeAsyncWithDashboard(),
 		},
 		{
 			name:    "accepted with malformed response",


### PR DESCRIPTION
Validation through implementation of [OSB 437](https://github.com/openservicebrokerapi/servicebroker/pull/437).

This is to allow Dashboard URL to be returned in the response body to a PATCH /v2/service_instances/:service_id request.