### PR TITLE
enforce required fields on fake ProvisionRequest

### DIFF
--- a/v2/fake/fake.go
+++ b/v2/fake/fake.go
@@ -249,6 +249,12 @@ func UnexpectedActionError() error {
 	return errors.New("Unexpected action")
 }
 
+// RequiredFieldsMissingError returns an error message indicating that
+// a required field was not set
+func RequiredFieldsMissingError() error {
+	return errors.New("A required field on the request was not set")
+}
+
 // CatalogReactionInterface defines the reaction to GetCatalog requests.
 type CatalogReactionInterface interface {
 	react() (*v2.CatalogResponse, error)
@@ -282,9 +288,12 @@ type ProvisionReaction struct {
 	Error    error
 }
 
-func (r *ProvisionReaction) react(_ *v2.ProvisionRequest) (*v2.ProvisionResponse, error) {
+func (r *ProvisionReaction) react(req *v2.ProvisionRequest) (*v2.ProvisionResponse, error) {
 	if r == nil {
 		return nil, UnexpectedActionError()
+	}
+	if req.ServiceID == "" || req.PlanID == "" || req.OrganizationGUID == "" || req.SpaceGUID == "" {
+		return nil, RequiredFieldsMissingError()
 	}
 	return r.Response, r.Error
 }

--- a/v2/fake/fake_test.go
+++ b/v2/fake/fake_test.go
@@ -220,6 +220,14 @@ func TestProvisionInstance(t *testing.T) {
 	}
 }
 
+func TestProvisionRequestRequiredFields(t *testing.T) {
+	fakeClient := &fake.FakeClient{}
+	_, err := fakeClient.ProvisionInstance(&v2.ProvisionRequest{})
+	if err == nil {
+		t.Fatalf("request should have failed for missing required fields")
+	}
+}
+
 func updateInstanceResponse() *v2.UpdateInstanceResponse {
 	return &v2.UpdateInstanceResponse{
 		Async: true,

--- a/v2/fake/fake_test.go
+++ b/v2/fake/fake_test.go
@@ -221,7 +221,7 @@ func TestProvisionInstance(t *testing.T) {
 }
 
 func TestProvisionRequestRequiredFields(t *testing.T) {
-	fakeClient := &fake.FakeClient{}
+	fakeClient := &fake.FakeClient{ProvisionReaction: &fake.ProvisionReaction{}}
 	_, err := fakeClient.ProvisionInstance(&v2.ProvisionRequest{})
 	if err == nil {
 		t.Fatalf("request should have failed for missing required fields")

--- a/v2/fake/fake_test.go
+++ b/v2/fake/fake_test.go
@@ -131,6 +131,15 @@ func TestGetCatalog(t *testing.T) {
 	}
 }
 
+func provisionRequest() *v2.ProvisionRequest {
+	return &v2.ProvisionRequest{
+		ServiceID:        "test-service-id",
+		PlanID:           "test-plan-id",
+		OrganizationGUID: "test-organization-guid",
+		SpaceGUID:        "test-space-guid",
+	}
+}
+
 func provisionResponse() *v2.ProvisionResponse {
 	return &v2.ProvisionResponse{
 		Async: true,
@@ -191,7 +200,7 @@ func TestProvisionInstance(t *testing.T) {
 			ProvisionReaction: tc.reaction,
 		}
 
-		response, err := fakeClient.ProvisionInstance(&v2.ProvisionRequest{})
+		response, err := fakeClient.ProvisionInstance(provisionRequest())
 
 		if !reflect.DeepEqual(tc.response, response) {
 			t.Errorf("%v: unexpected response; expected %+v, got %+v", tc.name, tc.response, response)


### PR DESCRIPTION
 - update test

@pmorie @duglin who has merge perms on this repo? 

for #121 to help enforce upstream usage in service-catalog.

Not required, but can be done piecemeal. Maybe good for new contributors?