### PR TITLE
return non-nil error when gets a http.StatusGone

### DIFF
--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -26,8 +26,10 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 	}
 
 	switch response.StatusCode {
-	case http.StatusOK, http.StatusGone:
+	case http.StatusOK:
 		return &DeprovisionResponse{}, nil
+	case http.StatusGone:
+		return &DeprovisionResponse{}, c.handleFailureResponse(response)
 	case http.StatusAccepted:
 		if !r.AcceptsIncomplete {
 			// If the client did not signify that it could handle asynchronous

--- a/v2/deprovision_instance_test.go
+++ b/v2/deprovision_instance_test.go
@@ -74,12 +74,13 @@ func TestDeprovisionInstance(t *testing.T) {
 			expectedResponse: successDeprovisionResponse(),
 		},
 		{
-			name: "success - gone",
+			name: "410 - gone, client error",
 			httpReaction: httpReaction{
 				status: http.StatusGone,
 				body:   successDeprovisionResponseBody,
 			},
-			expectedResponse: successDeprovisionResponse(),
+			expectedResponse:   successDeprovisionResponse(),
+			expectedErrMessage: "Status: 410; ErrorMessage: <nil>; Description: <nil>; ResponseError: <nil>",
 		},
 		{
 			name:    "success - async",


### PR DESCRIPTION
In DeprovisionInstance(), when gets back a http.StatusGone from broker,
return a non-nil error which includes this statusCode.
user can use IsGoneError() function defined in errors.go to verify such case.