### PR TITLE
Enable adding headers on request sent by the OSB client

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ This project does not aim to provide:
 
 ## Current status
 
-I'm currently just sketching around in my free time, but would love to
-eventually donate this repo to an organization if people decide that it is
-useful.
+This repository is used in the 
+[Kubernetes `service-catalog`](https://github.com/kubernetes-incubator/service-catalog)
+incubator repo.
 
 ## Why?
 

--- a/v2/client.go
+++ b/v2/client.go
@@ -17,7 +17,7 @@ import (
 const (
 	// XBrokerAPIVersion is the header for the Open Service Broker API
 	// version.
-	XBrokerAPIVersion = "X-Broker-Api-Version"
+	XBrokerAPIVersion = "X-Broker-API-Version"
 
 	catalogURL            = "%s/v2/catalog"
 	serviceInstanceURLFmt = "%s/v2/service_instances/%s"


### PR DESCRIPTION
Hi,

We use the Open Service Broker API in one of our projects. We consume this API using this client library. In our case, we would like to add some headers to the requests created by the OSB client. Mainly, our use case is to add these header for tracing purposes. To trace a request that propagates to different microservices running in different services, tracing frameworks like [opentracing](http://opentracing.io/) add headers to requests. Currently, there is no way to add headers to the requests created by this client. This PR introduces such ability.

Thanks!