### PR TITLE
Close the response Body

### DIFF
--- a/v2/bind.go
+++ b/v2/bind.go
@@ -75,6 +75,11 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		userResponse := &BindResponse{}

--- a/v2/client.go
+++ b/v2/client.go
@@ -271,6 +271,20 @@ func (c *client) validateAlphaAPIMethodsAllowed() error {
 	return nil
 }
 
+// drainReader reads and discards the remaining data in reader (for example
+// response body data) For HTTP this ensures that the http connection
+// could be reused for another request if the keepalive is enabled.
+// see https://gist.github.com/mholt/eba0f2cc96658be0f717#gistcomment-2605879
+// Not certain this is really needed here for the Broker vs a http server
+// but seems safe and worth including at this point
+func drainReader(reader io.Reader) error {
+	if reader == nil {
+		return nil
+	}
+	_, drainError := io.Copy(ioutil.Discard, io.LimitReader(reader, 4096))
+	return drainError
+}
+
 // internal message body types
 
 type asyncSuccessResponseBody struct {

--- a/v2/deprovision_instance.go
+++ b/v2/deprovision_instance.go
@@ -25,6 +25,11 @@ func (c *client) DeprovisionInstance(r *DeprovisionRequest) (*DeprovisionRespons
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK, http.StatusGone:
 		return &DeprovisionResponse{}, nil

--- a/v2/get_binding.go
+++ b/v2/get_binding.go
@@ -19,6 +19,11 @@ func (c *client) GetBinding(r *GetBindingRequest) (*GetBindingResponse, error) {
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK:
 		userResponse := &GetBindingResponse{}

--- a/v2/get_catalog.go
+++ b/v2/get_catalog.go
@@ -13,6 +13,11 @@ func (c *client) GetCatalog() (*CatalogResponse, error) {
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK:
 		catalogResponse := &CatalogResponse{}

--- a/v2/poll_binding_last_operation.go
+++ b/v2/poll_binding_last_operation.go
@@ -36,6 +36,11 @@ func (c *client) PollBindingLastOperation(r *BindingLastOperationRequest) (*Last
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK:
 		userResponse := &LastOperationResponse{}

--- a/v2/poll_last_operation.go
+++ b/v2/poll_last_operation.go
@@ -30,6 +30,11 @@ func (c *client) PollLastOperation(r *LastOperationRequest) (*LastOperationRespo
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK:
 		userResponse := &LastOperationResponse{}

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -52,6 +52,11 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusCreated, http.StatusOK:
 		userResponse := &ProvisionResponse{}

--- a/v2/unbind.go
+++ b/v2/unbind.go
@@ -37,6 +37,11 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 		return nil, err
 	}
 
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK, http.StatusGone:
 		userResponse := &UnbindResponse{}

--- a/v2/update_instance.go
+++ b/v2/update_instance.go
@@ -46,6 +46,12 @@ func (c *client) UpdateInstance(r *UpdateInstanceRequest) (*UpdateInstanceRespon
 	if err != nil {
 		return nil, err
 	}
+
+	defer func() {
+		drainReader(response.Body)
+		response.Body.Close()
+	}()
+
 	switch response.StatusCode {
 	case http.StatusOK:
 		responseBodyObj := &updateInstanceResponseBody{}


### PR DESCRIPTION
The Response Body should always be closed if there was no error executing the request.

See related issue https://github.com/kubernetes-incubator/service-catalog/issues/2276