### PR TITLE
use defaults from DefaultTransport for our custom transport (ie timeouts)

### DIFF
--- a/v2/client.go
+++ b/v2/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -38,7 +39,21 @@ func NewClient(config *ClientConfiguration) (Client, error) {
 	httpClient := &http.Client{
 		Timeout: time.Duration(config.TimeoutSeconds) * time.Second,
 	}
-	transport := &http.Transport{}
+
+	// use default values lifted from DefaultTransport
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
 	if config.TLSConfig != nil {
 		transport.TLSClientConfig = config.TLSConfig
 	} else {


### PR DESCRIPTION
fixes #132 

to test using k8s service catalog, do a `svcat sync broker ups-broker` repeatedly.  Without the fix, you see the number of established connections grow as reported by `sudo nsenter  -t $BROKERPID --net netstat -n -p`

With this fix, the number of established connections remains constant which is a small number related to the number of connections used within the last 90 seconds (IdleConnTimeout).