### PR TITLE
Migrate from glog to klog

### DIFF
--- a/v2/bind.go
+++ b/v2/bind.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 // internal message body types
@@ -114,7 +114,7 @@ func (c *client) Bind(r *BindRequest) (*BindResponse, error) {
 		}
 		if response.StatusCode == http.StatusAccepted {
 			if c.Verbose {
-				glog.Infof("broker %q: received asynchronous response", c.Name)
+				klog.Infof("broker %q: received asynchronous response", c.Name)
 			}
 			userResponse.Async = true
 		}

--- a/v2/client.go
+++ b/v2/client.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 const (
@@ -185,7 +185,7 @@ func (c *client) prepareAndDo(method, URL string, params map[string]string, body
 	}
 
 	if c.Verbose {
-		glog.Infof("broker %q: doing request to %q", c.Name, URL)
+		klog.Infof("broker %q: doing request to %q", c.Name, URL)
 	}
 
 	return c.doRequestFunc(request)
@@ -204,7 +204,7 @@ func (c *client) unmarshalResponse(response *http.Response, obj interface{}) err
 	}
 
 	if c.Verbose {
-		glog.Infof("broker %q: response body: %v, type: %T", c.Name, string(body), obj)
+		klog.Infof("broker %q: response body: %v, type: %T", c.Name, string(body), obj)
 	}
 
 	err = json.Unmarshal(body, obj)
@@ -218,7 +218,7 @@ func (c *client) unmarshalResponse(response *http.Response, obj interface{}) err
 // handleFailureResponse returns an HTTPStatusCodeError for the given
 // response.
 func (c *client) handleFailureResponse(response *http.Response) error {
-	glog.Info("handling failure responses")
+	klog.Info("handling failure responses")
 
 	httpErr := HTTPStatusCodeError{
 		StatusCode: response.StatusCode,

--- a/v2/generator/catalog.go
+++ b/v2/generator/catalog.go
@@ -7,7 +7,7 @@ import (
 
 	"sort"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/pmorie/go-open-service-broker-client/v2"
 )
 
@@ -69,7 +69,7 @@ func (g *Generator) GetCatalog() (*v2.CatalogResponse, error) {
 func getSliceWithoutDuplicates(count int, seed int64, list []string) []string {
 
 	if len(list) < count {
-		glog.Error("not enough items in list")
+		klog.Error("not enough items in list")
 		return []string{""}
 	}
 

--- a/v2/generator/catalog_test.go
+++ b/v2/generator/catalog_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 func TestGetCatalog(t *testing.T) {
@@ -47,7 +47,7 @@ func TestGetCatalog(t *testing.T) {
 
 	catalogJson := string(catalogBytes)
 
-	glog.Info(catalogJson)
+	klog.Info(catalogJson)
 }
 
 func TestGetPlans(t *testing.T) {
@@ -55,6 +55,6 @@ func TestGetPlans(t *testing.T) {
 	g := Generator{
 		PlanPool: []string{"AAA", "BBB", "CCC", "DDD", "EEE"},
 	}
-	glog.Info(g.planNames(1, 5))
-	glog.Info(g.planNames(2, 5))
+	klog.Info(g.planNames(1, 5))
+	klog.Info(g.planNames(2, 5))
 }

--- a/v2/generator/generator_test.go
+++ b/v2/generator/generator_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 func TestCreateGenerator(t *testing.T) {
@@ -34,5 +34,5 @@ func TestCreateGenerator(t *testing.T) {
 
 	catalogJson := string(catalogBytes)
 
-	glog.Info(catalogJson)
+	klog.Info(catalogJson)
 }

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -64,7 +64,7 @@ type ClientConfiguration struct {
 	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
 	// This CA certificate will be added to any specified in TLSConfig.RootCAs.
 	CAData []byte
-	// Verbose is whether the client will log to glog.
+	// Verbose is whether the client will log to klog.
 	Verbose bool
 }
 

--- a/v2/provision_instance.go
+++ b/v2/provision_instance.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 // internal message body types
@@ -95,7 +95,7 @@ func (c *client) ProvisionInstance(r *ProvisionRequest) (*ProvisionResponse, err
 		}
 
 		if c.Verbose {
-			glog.Infof("broker %q: received asynchronous response", c.Name)
+			klog.Infof("broker %q: received asynchronous response", c.Name)
 		}
 
 		return userResponse, nil

--- a/v2/unbind.go
+++ b/v2/unbind.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 type unbindSuccessResponseBody struct {
@@ -72,7 +72,7 @@ func (c *client) Unbind(r *UnbindRequest) (*UnbindResponse, error) {
 		}
 		if response.StatusCode == http.StatusAccepted {
 			if c.Verbose {
-				glog.Infof("broker %q: received asynchronous response", c.Name)
+				klog.Infof("broker %q: received asynchronous response", c.Name)
 			}
 			userResponse.Async = true
 		}


### PR DESCRIPTION
I'm trying to migrate service catalog to kube 1.13 libraries. glog has been forked into [klog](https://github.com/kubernetes/klog) and everything has been migrated to it (see https://github.com/kubernetes/kubernetes/pull/70889). I'm just doing the same thing in this repo so that service catalog does not depend on glog anymore.