### PR TITLE
v2/errors.go: Add constants for concurrency error

### DIFF
--- a/v2/errors.go
+++ b/v2/errors.go
@@ -87,12 +87,14 @@ func IsConflictError(err error) bool {
 	return statusCodeError.StatusCode == http.StatusConflict
 }
 
-// Constants are used to check for "Async" and "RequiresApp" errors and their messages
+// Constants are used to check for spec-mandated errors and their messages
 const (
 	AsyncErrorMessage               = "AsyncRequired"
 	AsyncErrorDescription           = "This service plan requires client support for asynchronous service operations."
 	AppGUIDRequiredErrorMessage     = "RequiresApp"
 	AppGUIDRequiredErrorDescription = "This service supports generation of credentials through binding an application only."
+	ConcurrencyErrorMessage         = "ConcurrencyError"
+	ConcurrencyErrorDescription     = "The Service Broker does not support concurrent requests that mutate the same resource."
 )
 
 // IsAsyncRequiredError returns whether the error corresponds to the
@@ -141,6 +143,30 @@ func IsAppGUIDRequiredError(err error) bool {
 	}
 
 	return *statusCodeError.Description == AppGUIDRequiredErrorDescription
+}
+
+// IsConcurrencyError returns whether the error corresponds to the
+// conventional way of indicating that a service broker does not support
+// concurrent requests to modify the same resource
+func IsConcurrencyError(err error) bool {
+	statusCodeError, ok := err.(HTTPStatusCodeError)
+	if !ok {
+		return false
+	}
+
+	if statusCodeError.StatusCode != http.StatusUnprocessableEntity {
+		return false
+	}
+
+	if statusCodeError.ErrorMessage == nil || statusCodeError.Description == nil {
+		return false
+	}
+
+	if *statusCodeError.ErrorMessage != ConcurrencyErrorMessage {
+		return false
+	}
+
+	return *statusCodeError.Description == ConcurrencyErrorDescription
 }
 
 // AlphaAPIMethodsNotAllowedError is an error type signifying that alpha API

--- a/v2/errors_test.go
+++ b/v2/errors_test.go
@@ -161,6 +161,15 @@ func TestIsAsyncRequiredError(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "concurrency error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(ConcurrencyErrorMessage),
+				Description:  strPtr(ConcurrencyErrorDescription),
+			},
+			expected: false,
+		},
+		{
 			name: "no error message",
 			err: HTTPStatusCodeError{
 				StatusCode:  http.StatusUnprocessableEntity,
@@ -222,6 +231,15 @@ func TestIsAppGUIDRequiredError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "concurrency error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(ConcurrencyErrorMessage),
+				Description:  strPtr(ConcurrencyErrorDescription),
+			},
+			expected: false,
+		},
+		{
 			name: "no error message",
 			err: HTTPStatusCodeError{
 				StatusCode:  http.StatusUnprocessableEntity,
@@ -241,6 +259,76 @@ func TestIsAppGUIDRequiredError(t *testing.T) {
 
 	for _, tc := range cases {
 		if e, a := tc.expected, IsAppGUIDRequiredError(tc.err); e != a {
+			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+func TestConcurrencyError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "non-http error",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		{
+			name: "other http error",
+			err: HTTPStatusCodeError{
+				StatusCode: http.StatusForbidden,
+			},
+			expected: false,
+		},
+		{
+			name: "async required error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(AsyncErrorMessage),
+				Description:  strPtr(AsyncErrorDescription),
+			},
+			expected: false,
+		},
+		{
+			name: "app guid required error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(AppGUIDRequiredErrorMessage),
+				Description:  strPtr(AppGUIDRequiredErrorDescription),
+			},
+			expected: false,
+		},
+		{
+			name: "concurrency error",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(ConcurrencyErrorMessage),
+				Description:  strPtr(ConcurrencyErrorDescription),
+			},
+			expected: true,
+		},
+		{
+			name: "no error message",
+			err: HTTPStatusCodeError{
+				StatusCode:  http.StatusUnprocessableEntity,
+				Description: strPtr(AppGUIDRequiredErrorDescription),
+			},
+			expected: false,
+		},
+		{
+			name: "no description",
+			err: HTTPStatusCodeError{
+				StatusCode:   http.StatusUnprocessableEntity,
+				ErrorMessage: strPtr(AppGUIDRequiredErrorMessage),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		if e, a := tc.expected, IsConcurrencyError(tc.err); e != a {
 			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
 		}
 	}

--- a/v2/fake/fake.go
+++ b/v2/fake/fake.go
@@ -480,3 +480,13 @@ func AppGUIDRequiredError() error {
 		Description:  strPtr(v2.AppGUIDRequiredErrorDescription),
 	}
 }
+
+// ConcurrencyError returns error for when concurrent requests to modify the
+// same resource is rejected.
+func ConcurrencyError() error {
+	return v2.HTTPStatusCodeError{
+		StatusCode:   http.StatusUnprocessableEntity,
+		ErrorMessage: strPtr(v2.ConcurrencyErrorMessage),
+		Description:  strPtr(v2.ConcurrencyErrorDescription),
+	}
+}

--- a/v2/fake/fake_test.go
+++ b/v2/fake/fake_test.go
@@ -872,6 +872,11 @@ func TestFakeAsyncRequiredError(t *testing.T) {
 			err:      fake.AppGUIDRequiredError(),
 			expected: false,
 		},
+		{
+			name:     "concurrency error",
+			err:      fake.ConcurrencyError(),
+			expected: false,
+		},
 	}
 
 	for _, tc := range cases {
@@ -897,10 +902,45 @@ func TestFakeAppGUIDRequiredError(t *testing.T) {
 			err:      fake.AppGUIDRequiredError(),
 			expected: true,
 		},
+		{
+			name:     "concurrency error",
+			err:      fake.ConcurrencyError(),
+			expected: false,
+		},
 	}
 
 	for _, tc := range cases {
 		if e, a := tc.expected, v2.IsAppGUIDRequiredError(tc.err); e != a {
+			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
+		}
+	}
+}
+
+func TestFakeConcurrencyError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "async required error",
+			err:      fake.AsyncRequiredError(),
+			expected: false,
+		},
+		{
+			name:     "app guid required error",
+			err:      fake.AppGUIDRequiredError(),
+			expected: false,
+		},
+		{
+			name:     "concurrency error",
+			err:      fake.ConcurrencyError(),
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		if e, a := tc.expected, v2.IsConcurrencyError(tc.err); e != a {
 			t.Errorf("%v: expected %v, got %v", tc.name, e, a)
 		}
 	}


### PR DESCRIPTION
This adds constants for ConcurrencyError, as documented in the [2.14 spec](https://github.com/openservicebrokerapi/servicebroker/blob/v2.14/spec.md#error-codes)

I was going to change `AsyncErrorDescription` to not specifically mention service plans, but then I realized that `IsAsyncRequiredError` actually specifically checks the description (and not just the message) for equality; it seems possible that changing the description would break backwards compatibility.

(`ConcurrencyError` is useful when implementing asynchronous operations.)